### PR TITLE
Add per-IdP SP metadata endpoint

### DIFF
--- a/samlauth_multi_idp.routing.yml
+++ b/samlauth_multi_idp.routing.yml
@@ -39,3 +39,12 @@ samlauth_multi_idp.multi_login_form:
     _user_is_logged_in: 'FALSE'
   options:
     _maintenance_access: TRUE
+
+samlauth_multi_idp.saml_metadata:
+  path: '/saml/metadata/{samlauth_idp}'
+  defaults:
+    _controller: '\Drupal\samlauth_multi_idp\Controller\MultiIdpController::metadata'
+  requirements:
+    _access: 'TRUE'
+  options:
+    _maintenance_access: TRUE

--- a/src/Controller/MultiIdpController.php
+++ b/src/Controller/MultiIdpController.php
@@ -7,6 +7,9 @@ use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\samlauth_multi_idp\MultiIdpSamlService;
+use Drupal\samlauth_multi_idp\SamlauthIdpInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Returns responses for samlauth_multi_idp module routes.
@@ -20,13 +23,22 @@ class MultiIdpController extends ControllerBase {
    */
   protected $entityTypeManager;
 
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  /**
+   * The SAML service.
+   *
+   * @var \Drupal\samlauth_multi_idp\MultiIdpSamlService
+   */
+  protected $samlService;
+
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, MultiIdpSamlService $saml_service) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->samlService = $saml_service;
   }
 
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('samlauth.saml')
     );
   }
 
@@ -66,6 +78,19 @@ class MultiIdpController extends ControllerBase {
     ];
 
     return $build;
+  }
+
+  /**
+   * Returns SAML metadata for a specific IdP configuration.
+   */
+  public function metadata(SamlauthIdpInterface $samlauth_idp) {
+    $request = \Drupal::request();
+    $allow_invalid = $request->query->get('check', '1') === '0';
+    $validity = $request->query->get('validity');
+    $cache_duration = $request->query->get('cache');
+
+    $metadata = $this->samlService->getMetadata($validity, $cache_duration, $allow_invalid, $samlauth_idp);
+    return new Response($metadata, 200, ['Content-Type' => 'text/xml']);
   }
 
 }

--- a/src/MultiIdpSamlService.php
+++ b/src/MultiIdpSamlService.php
@@ -214,7 +214,9 @@ class MultiIdpSamlService extends SamlService {
    *   (Optional) number of seconds used for the 'cacheDuration' property of
    *   the metadata. If left empty, the SAML PHP Toolkit will assign a value.
    * @param bool $allow_invalid
-   *   (Optional) also return metadata if it cannot be validated.
+  *   (Optional) also return metadata if it cannot be validated.
+   * @param \Drupal\samlauth_multi_idp\Entity\SamlauthIdp|null $idp
+   *   (Optional) IdP configuration used to generate SP metadata.
    *
    * @return mixed
    *   XML string representing metadata.
@@ -222,11 +224,11 @@ class MultiIdpSamlService extends SamlService {
    * @throws \OneLogin\Saml2\Error
    *   If the metatdad is invalid.
    */
-  public function getMetadata($validity = NULL, $cache_duration = NULL, bool $allow_invalid = FALSE) {
+  public function getMetadata($validity = NULL, $cache_duration = NULL, bool $allow_invalid = FALSE, ?SamlauthIdp $idp = NULL) {
     // It's actually strange how we need to instantiate an Auth object when
     // we only need the Settings object. We may refactor that when refactoring
     // getSamlAuth().
-    $settings = $this->getSamlAuth('metadata')->getSettings();
+    $settings = $this->getSamlAuth('metadata', TRUE, $idp)->getSettings();
     $metadata = $settings->getSPMetadata(FALSE, $validity, $cache_duration);
     if (!$allow_invalid) {
       $errors = $settings->validateMetadata($metadata);

--- a/src/SamlauthIdpListBuilder.php
+++ b/src/SamlauthIdpListBuilder.php
@@ -6,6 +6,7 @@ namespace Drupal\samlauth_multi_idp;
 
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 
 /**
  * Provides a listing of identity providers.
@@ -28,7 +29,14 @@ final class SamlauthIdpListBuilder extends ConfigEntityListBuilder {
     /** @var \Drupal\samlauth_multi_idp\SamlauthIdpInterface $entity */
     $row['label'] = $entity->label();
     $row['id'] = $entity->id();
-    return $row + parent::buildRow($entity);
+    $row = $row + parent::buildRow($entity);
+
+    $row['operations']['data']['#links']['metadata'] = [
+      'title' => $this->t('Metadata'),
+      'url' => Url::fromRoute('samlauth_multi_idp.saml_metadata', ['samlauth_idp' => $entity->id()]),
+    ];
+
+    return $row;
   }
 
 }


### PR DESCRIPTION
## Summary
- allow Saml service to generate metadata for a specific IdP
- expose `/saml/metadata/{samlauth_idp}` endpoint and link from IdP list

## Testing
- `php -l src/MultiIdpSamlService.php`
- `php -l src/Controller/MultiIdpController.php`
- `php -l src/SamlauthIdpListBuilder.php`


------
https://chatgpt.com/codex/tasks/task_e_6893c2112020832691f6d1d3e0047472